### PR TITLE
Refatorar o comando help

### DIFF
--- a/pugsebot/bot.py
+++ b/pugsebot/bot.py
@@ -1,11 +1,9 @@
-import os
-
 from telegram.ext import Updater, CommandHandler
 from telegram import ParseMode
 
 from utils.logging import bot_logger
 from utils.environment import TARGET_CHAT_ID, TOKEN, ENVIRONMENT_MODE, PORT
-from utils.module import get_commands_by_path
+from utils.module import get_commands
 
 class PUGSEBot:
     logger = bot_logger
@@ -57,15 +55,10 @@ class PUGSEBot:
             return bot_reply_func(**create_content_func(update, context),)
         return reply_content
 
-    def get_commands_path(self):
-        current_directory = os.path.dirname(os.path.abspath(__file__))
-        commands_path = os.path.join(current_directory, 'commands')
-        return commands_path
-
     def add_commands(self):
         # add commands
         self.dp = self.updater.dispatcher
-        command_module_list = get_commands_by_path(self.get_commands_path())
+        command_module_list = get_commands()
         for command_module in command_module_list:
             command = command_module.name
             content_function = command_module.do_command

--- a/pugsebot/bot.py
+++ b/pugsebot/bot.py
@@ -1,15 +1,15 @@
+import os
+
 from telegram.ext import Updater, CommandHandler
 from telegram import ParseMode
 
 from utils.logging import bot_logger
 from utils.environment import TARGET_CHAT_ID, TOKEN, ENVIRONMENT_MODE, PORT
-
-from commands import command_list
+from utils.module import get_commands_by_path
 
 class PUGSEBot:
     logger = bot_logger
     chat_id = TARGET_CHAT_ID
-    command_module_list = command_list
 
     def reply_text(self, **kwargs):
         update = kwargs['update']
@@ -57,11 +57,17 @@ class PUGSEBot:
             return bot_reply_func(**create_content_func(update, context),)
         return reply_content
 
+    def get_commands_path(self):
+        current_directory = os.path.dirname(os.path.abspath(__file__))
+        commands_path = os.path.join(current_directory, 'commands')
+        return commands_path
+
     def add_commands(self):
         text = 'Comandos aceitos: \n'
         # add commands
         self.dp = self.updater.dispatcher
-        for command_module in self.command_module_list:
+        command_module_list = get_commands_by_path(self.get_commands_path())
+        for command_module in command_module_list:
             command = command_module.name
             content_function = command_module.do_command
             reply_method = getattr(

--- a/pugsebot/bot.py
+++ b/pugsebot/bot.py
@@ -63,7 +63,6 @@ class PUGSEBot:
         return commands_path
 
     def add_commands(self):
-        text = 'Comandos aceitos: \n'
         # add commands
         self.dp = self.updater.dispatcher
         command_module_list = get_commands_by_path(self.get_commands_path())
@@ -75,7 +74,6 @@ class PUGSEBot:
                 command_module.reply_function_name,
             )
 
-            text += f'/{command}: {command_module.help_text}\n'
             self.dp.add_handler(
                 CommandHandler(
                     command,
@@ -85,10 +83,6 @@ class PUGSEBot:
                     ),
                 ),
             )
-
-        def help_command(update, context):
-            return self.reply_text(update=update, response=text)
-        self.dp.add_handler(CommandHandler('help', help_command))
 
     def start(self):
         if ENVIRONMENT_MODE == 'PRODUCTION':

--- a/pugsebot/commands/__init__.py
+++ b/pugsebot/commands/__init__.py
@@ -1,7 +1,0 @@
-import os
-
-from utils.module import get_commands_from_path
-
-command_list = get_commands_from_path(
-    os.path.dirname(os.path.abspath(__file__))
-)

--- a/pugsebot/commands/__init__.py
+++ b/pugsebot/commands/__init__.py
@@ -1,38 +1,7 @@
-from utils.command_base import CommandBase
-
 import os
 
-def get_module_names():
-    path = os.path.dirname(os.path.abspath(__file__))
-    modules_names = []
-    for module_filename in os.listdir(path):
-        if module_filename != '__init__.py'\
-                and '.py' in module_filename:
-            modules_names.append(
-                module_filename.replace('.py', ''))
-    return modules_names
+from utils.module import get_commands_from_path
 
-def get_modules(modules_names):
-    modules = []
-    for module_name in modules_names:
-        modules.append(
-            __import__(
-                'commands.' + module_name,
-                fromlist=[module_name]))
-    return modules
-
-def get_commands(modules):
-    command_list = []
-    for module in modules:
-        for attr_str in dir(module):
-            attr = getattr(module, attr_str)
-            if not isinstance(attr, type) or attr == CommandBase:
-                continue
-            if issubclass(attr, CommandBase):
-                command_list.append(attr())
-    return command_list
-
-_modules_names = get_module_names()
-_modules = get_modules(_modules_names)
-
-command_list = get_commands(_modules)
+command_list = get_commands_from_path(
+    os.path.dirname(os.path.abspath(__file__))
+)

--- a/pugsebot/commands/help.py
+++ b/pugsebot/commands/help.py
@@ -1,13 +1,8 @@
-import os
-
 from utils.command_base import CommandBase
-from utils.module import get_commands_by_path
+from utils.module import get_commands
 
 MESSAGE_HEADER = 'Comandos aceitos:'
 TEMPLATE_MESSAGE = '\n/{}: {}'
-
-def get_commands_path():
-    return os.path.dirname(os.path.abspath(__file__))
 
 class Help(CommandBase):
     def __init__(self):
@@ -20,7 +15,7 @@ class Help(CommandBase):
 
     def function(self, update=None, context=None):
         text = MESSAGE_HEADER
-        command_list = get_commands_by_path(get_commands_path())
+        command_list = get_commands()
         for command in command_list:
             text += TEMPLATE_MESSAGE.format(command.name, command.help_text)
         return text

--- a/pugsebot/commands/help.py
+++ b/pugsebot/commands/help.py
@@ -1,0 +1,26 @@
+import os
+
+from utils.command_base import CommandBase
+from utils.module import get_commands_by_path
+
+MESSAGE_HEADER = 'Comandos aceitos:'
+TEMPLATE_MESSAGE = '\n/{}: {}'
+
+def get_commands_path():
+    return os.path.dirname(os.path.abspath(__file__))
+
+class Help(CommandBase):
+    def __init__(self):
+        super().__init__(
+            name='help',
+            help_text='Mostra os comandos aceitos pelo Bot',
+            reply_function_name='reply_text',
+            schedule_interval=None,
+        )
+
+    def function(self, update=None, context=None):
+        text = MESSAGE_HEADER
+        command_list = get_commands_by_path(get_commands_path())
+        for command in command_list:
+            text += TEMPLATE_MESSAGE.format(command.name, command.help_text)
+        return text

--- a/pugsebot/tests.py
+++ b/pugsebot/tests.py
@@ -2,6 +2,7 @@ import unittest
 import json
 import time
 import datetime
+import os
 
 from telegram.update import Update
 from telegram.message import Message
@@ -9,6 +10,14 @@ from telegram.message import Message
 import bot
 import utils
 import commands
+import commands.about
+import commands.faq
+import commands.links
+import commands.memes
+import commands.news
+import commands.projects
+import commands.say
+import commands.udemy
 
 utils.logging.set_level('ERROR')
 
@@ -22,6 +31,11 @@ def mock_update(message_text):
 def mock_reply_method(update=None, content=None):
     return mock_update(content)
 
+def get_commands_path():
+    current_directory = os.path.dirname(os.path.abspath(__file__))
+    commands_path = os.path.join(current_directory, 'commands')
+    return commands_path
+
 class TestPUGSEBot(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
@@ -30,13 +44,12 @@ class TestPUGSEBot(unittest.TestCase):
 
     def test_add_commands(self):
         handler_list = self.bot.dp.handlers[0]
+        command_list = utils.module.get_commands_by_path(get_commands_path())
         self.assertEqual(
             len(handler_list) - 1,
-            len(commands.command_list),
+            len(command_list),
         )
-        name_list1 = [
-            command.name for command in commands.command_list
-        ]
+        name_list1 = [command.name for command in command_list]
         name_list2 = []
         for handler in handler_list:
             name_list2.append(handler.command[0])
@@ -53,17 +66,32 @@ class TestPUGSEBot(unittest.TestCase):
         self.assertIn('help', name_list)
 
 class TestUtilsInit(unittest.TestCase):
-    def test_get_module_names(self):
-        names = commands.get_module_names()
-        for name in names:
-            self.assertTrue(
-                hasattr(commands, name)
-            )
+    @classmethod
+    def setUpClass(cls):
+        cls.commands_path = get_commands_path()
+        cls.commands_module_name = 'commands'
 
-    def test_get_modules(self):
-        names = commands.get_module_names()
-        modules = commands.get_modules(names)
+    def assert_get_commands(self, command_list):
+        Base = utils.command_base.CommandBase
+        for command in command_list:
+            self.assertNotEqual(type(command), Base)
+            self.assertTrue(isinstance(command, Base))
 
+    def test_get_commands_by_path(self):
+        command_list = utils.module.get_commands_by_path(self.commands_path)
+        self.assert_get_commands(command_list)
+
+    def test_get_commands_by_modules(self):
+        names = utils.module.get_modules_names(self.commands_path)
+        modules = utils.module.get_modules_by_names(
+            names,
+            self.commands_module_name,
+        )
+        command_list = utils.module.get_commands_by_modules(modules)
+
+        self.assert_get_commands(command_list)
+
+    def assert_get_modules(self, modules):
         attr_names = dir(commands)
         attr_list = [
             getattr(commands, attr_str) for attr_str in attr_names
@@ -72,17 +100,30 @@ class TestUtilsInit(unittest.TestCase):
         for module in modules:
             self.assertIn(module, attr_list)
 
-    def test_get_commands(self):
-        names = commands.get_module_names()
-        modules = commands.get_modules(names)
-        command_list = commands.get_commands(modules)
+    def test_get_modules_by_path(self):
+        modules = utils.module.get_modules_by_path(self.commands_path)
 
-        Base = utils.command_base.CommandBase
-        for command in command_list:
-            self.assertNotEqual(
-                type(command), Base)
+        self.assert_get_modules(modules)
+
+    def test_get_modules_by_names(self):
+        names = utils.module.get_modules_names(self.commands_path)
+        modules = utils.module.get_modules_by_names(
+            names,
+            self.commands_module_name,
+        )
+
+        self.assert_get_modules(modules)
+
+    def test_get_module_names(self):
+        names = utils.module.get_modules_names(self.commands_path)
+        for name in names:
             self.assertTrue(
-                isinstance(command, Base))
+                hasattr(commands, name)
+            )
+
+    def test_get_package_name(self):
+        name = utils.module.get_package_name(self.commands_path)
+        self.assertEqual(name, self.commands_module_name)
 
 class TestUtilsDatabaseCache(unittest.TestCase):
     @classmethod

--- a/pugsebot/tests.py
+++ b/pugsebot/tests.py
@@ -18,6 +18,7 @@ import commands.news
 import commands.projects
 import commands.say
 import commands.udemy
+import commands.help
 
 utils.logging.set_level('ERROR')
 
@@ -45,25 +46,12 @@ class TestPUGSEBot(unittest.TestCase):
     def test_add_commands(self):
         handler_list = self.bot.dp.handlers[0]
         command_list = utils.module.get_commands_by_path(get_commands_path())
-        self.assertEqual(
-            len(handler_list) - 1,
-            len(command_list),
-        )
+        self.assertEqual(len(handler_list), len(command_list))
         name_list1 = [command.name for command in command_list]
         name_list2 = []
         for handler in handler_list:
             name_list2.append(handler.command[0])
-        self.assertEqual(
-            set(name_list1).symmetric_difference(set(name_list2)),
-            set(['help']),
-        )
-
-    def test_help(self):
-        handler_list = self.bot.dp.handlers[0]
-        name_list = [
-            handler.command[0] for handler in handler_list
-        ]
-        self.assertIn('help', name_list)
+        self.assertEqual(set(name_list1), set(name_list2))
 
 class TestUtilsInit(unittest.TestCase):
     @classmethod
@@ -595,6 +583,13 @@ class TestFAQ(unittest.TestCase):
         result = commands.faq.FAQ().function()
         self.assertIn('O que é Python?', result)
         self.assertIn('https://www.python.org/dev/peps/pep-0008', result)
+
+class TestHelp(unittest.TestCase):
+    def test_function(self):
+        result = commands.help.Help().function()
+        self.assertIn('/help', result)
+        self.assertIn('/udemy', result)
+        self.assertIn('/news', result)
 
 if __name__ == '__main__':
     unittest.main()

--- a/pugsebot/tests.py
+++ b/pugsebot/tests.py
@@ -2,7 +2,6 @@ import unittest
 import json
 import time
 import datetime
-import os
 
 from telegram.update import Update
 from telegram.message import Message
@@ -32,11 +31,6 @@ def mock_update(message_text):
 def mock_reply_method(update=None, content=None):
     return mock_update(content)
 
-def get_commands_path():
-    current_directory = os.path.dirname(os.path.abspath(__file__))
-    commands_path = os.path.join(current_directory, 'commands')
-    return commands_path
-
 class TestPUGSEBot(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
@@ -45,7 +39,7 @@ class TestPUGSEBot(unittest.TestCase):
 
     def test_add_commands(self):
         handler_list = self.bot.dp.handlers[0]
-        command_list = utils.module.get_commands_by_path(get_commands_path())
+        command_list = utils.module.get_commands()
         self.assertEqual(len(handler_list), len(command_list))
         name_list1 = [command.name for command in command_list]
         name_list2 = []
@@ -56,7 +50,7 @@ class TestPUGSEBot(unittest.TestCase):
 class TestUtilsInit(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
-        cls.commands_path = get_commands_path()
+        cls.commands_path = utils.module.get_commands_path()
         cls.commands_module_name = 'commands'
 
     def assert_get_commands(self, command_list):
@@ -65,8 +59,8 @@ class TestUtilsInit(unittest.TestCase):
             self.assertNotEqual(type(command), Base)
             self.assertTrue(isinstance(command, Base))
 
-    def test_get_commands_by_path(self):
-        command_list = utils.module.get_commands_by_path(self.commands_path)
+    def test_get_commands(self):
+        command_list = utils.module.get_commands()
         self.assert_get_commands(command_list)
 
     def test_get_commands_by_modules(self):

--- a/pugsebot/utils/module.py
+++ b/pugsebot/utils/module.py
@@ -1,0 +1,59 @@
+import os
+
+from utils.command_base import CommandBase
+
+def get_commands_from_path(path):
+    modules = get_modules_from_path(path)
+    return get_commands_from_modules(modules)
+
+def get_commands_from_modules(modules):
+    command_list = []
+    for module in modules:
+        for attr_str in dir(module):
+            attr = getattr(module, attr_str)
+            if not isinstance(attr, type) or attr == CommandBase:
+                continue
+            if issubclass(attr, CommandBase):
+                command_list.append(attr())
+    return command_list
+
+def get_modules_from_path(path):
+    modules_names = get_modules_names(path)
+    package_name = get_package_name(path)
+    return get_modules_from_names(modules_names, package_name)
+
+def get_modules_from_names(modules_names, package_name):
+    modules = []
+    for module_name in modules_names:
+        modules.append(
+            __import__(
+                '{}.{}'.format(package_name, module_name),
+                fromlist=[module_name],
+            )
+        )
+    return modules
+
+def get_modules_names(path):
+    modules_names = []
+    for module_filename in os.listdir(path):
+        if module_filename != '__init__.py' and '.py' in module_filename:
+            modules_names.append(module_filename.replace('.py', ''))
+    return modules_names
+
+def get_package_name(path):
+    package_name = None
+    package_path = path
+
+    while os.path.exists(os.path.join(package_path, '__init__.py')):
+        current_package_name = os.path.basename(package_path)
+        package_path = os.path.dirname(package_path)
+
+        if package_name is None:
+            package_name = current_package_name
+        else:
+            package_name = '{}.{}'.format(current_package_name, package_name)
+
+    if package_name is None:
+        raise ValueError('You must set a "path" that is a python package.')
+
+    return package_name

--- a/pugsebot/utils/module.py
+++ b/pugsebot/utils/module.py
@@ -2,11 +2,16 @@ import os
 
 from utils.command_base import CommandBase
 
-def get_commands_from_path(path):
-    modules = get_modules_from_path(path)
-    return get_commands_from_modules(modules)
+PATH_COMMANDS = {}
+PATH_MODULES = {}
 
-def get_commands_from_modules(modules):
+def get_commands_by_path(path):
+    if path not in PATH_COMMANDS:
+        modules = get_modules_by_path(path)
+        PATH_COMMANDS[path] = get_commands_by_modules(modules)
+    return PATH_COMMANDS[path]
+
+def get_commands_by_modules(modules):
     command_list = []
     for module in modules:
         for attr_str in dir(module):
@@ -17,12 +22,14 @@ def get_commands_from_modules(modules):
                 command_list.append(attr())
     return command_list
 
-def get_modules_from_path(path):
-    modules_names = get_modules_names(path)
-    package_name = get_package_name(path)
-    return get_modules_from_names(modules_names, package_name)
+def get_modules_by_path(path):
+    if path not in PATH_MODULES:
+        modules_names = get_modules_names(path)
+        package_name = get_package_name(path)
+        PATH_MODULES[path] = get_modules_by_names(modules_names, package_name)
+    return PATH_MODULES[path]
 
-def get_modules_from_names(modules_names, package_name):
+def get_modules_by_names(modules_names, package_name):
     modules = []
     for module_name in modules_names:
         modules.append(

--- a/pugsebot/utils/module.py
+++ b/pugsebot/utils/module.py
@@ -2,14 +2,23 @@ import os
 
 from utils.command_base import CommandBase
 
-PATH_COMMANDS = {}
 PATH_MODULES = {}
 
-def get_commands_by_path(path):
-    if path not in PATH_COMMANDS:
-        modules = get_modules_by_path(path)
-        PATH_COMMANDS[path] = get_commands_by_modules(modules)
-    return PATH_COMMANDS[path]
+command_list = None
+
+def get_commands():
+    global command_list
+    if command_list is None:
+        modules = get_modules_by_path(get_commands_path())
+        command_list = get_commands_by_modules(modules)
+    return command_list
+
+def get_commands_path():
+    root_directory = os.path.dirname(
+        os.path.dirname(os.path.abspath(__file__))
+    )
+    commands_path = os.path.join(root_directory, 'commands')
+    return commands_path
 
 def get_commands_by_modules(modules):
     command_list = []


### PR DESCRIPTION
- Criado um módulo utilitário para realizar a importação de módulos de um determinado pacote;
- Removida a importação dos módulos do pacote `commands` do arquivo `__init__.py`;
- Comando `/help` foi movido para o seu respectivo módulo.