### PR TITLE
adicionado comando packt, testes atualizados, preview de link desabitados

### DIFF
--- a/pugsebot/bot.py
+++ b/pugsebot/bot.py
@@ -41,7 +41,7 @@ class PUGSEBot:
             update.message.reply_text(
                 text,
                 parse_mode=ParseMode.HTML,
-            )
+                disable_web_page_preview=True)
         return text
 
     def reply_photo(self, **kwargs):
@@ -72,7 +72,7 @@ class PUGSEBot:
                 chat_id=self.chat_id,
                 text=text,
                 parse_mode=ParseMode.HTML,
-            )
+                disable_web_page_preview=True)
         return text
 
     def send_photo(self, **kwargs):

--- a/pugsebot/commands/book.py
+++ b/pugsebot/commands/book.py
@@ -23,11 +23,11 @@ class Book(CommandBase):
         """Return a free book from Packt Learning."""
         start_date = datetime.datetime.now()
         end_date = start_date + datetime.timedelta(days=1)
-        start_fate_formated = start_date.strftime('%Y-%m-%d')
+        start_date_formated = start_date.strftime('%Y-%m-%d')
         end_date_formated = end_date.strftime('%Y-%m-%d')
         promotion_url = (
             'https://services.packtpub.com/free-learning-v1/'
-            f'offers?dateFrom={start_fate_formated}&dateTo={end_date_formated}'
+            f'offers?dateFrom={start_date_formated}&dateTo={end_date_formated}'
         )
         promotion_response_json = get_json(promotion_url)
         book_id = promotion_response_json['data'][0]['productId']

--- a/pugsebot/commands/book.py
+++ b/pugsebot/commands/book.py
@@ -13,7 +13,7 @@ class Book(CommandBase):
         """Pass arguments to CommandBase init."""
         super().__init__(
             name='book',
-            help_text='Livro gratúito do Packt Learning',
+            help_text='Livro gratuito do Packt Learning',
             reply_function_name='reply_text',
             schedule_interval=UM_DIA_EM_SEGUNDOS,
             expire=UM_DIA_EM_SEGUNDOS,
@@ -21,22 +21,22 @@ class Book(CommandBase):
 
     def function(self, update=None, context=None):
         """Return a free book from Packt Learning."""
-        startDate = datetime.datetime.now()
-        endDate = startDate + datetime.timedelta(days=1)
-        startDateFormated = startDate.strftime('%Y-%m-%d')
-        endDateFormated = endDate.strftime('%Y-%m-%d')
+        start_date = datetime.datetime.now()
+        end_date = start_date + datetime.timedelta(days=1)
+        start_fate_formated = start_date.strftime('%Y-%m-%d')
+        end_date_formated = end_date.strftime('%Y-%m-%d')
         promotion_url = (
             'https://services.packtpub.com/free-learning-v1/'
-            f'offers?dateFrom={startDateFormated}&dateTo={endDateFormated}'
+            f'offers?dateFrom={start_fate_formated}&dateTo={end_date_formated}'
         )
         promotion_response_json = get_json(promotion_url)
         book_id = promotion_response_json['data'][0]['productId']
 
-        url = (
+        book_url = (
             'https://static.packt-cdn.com/products/'
             f'{book_id}/summary'
         )
-        book_response_json = get_json(url)
+        book_response_json = get_json(book_url)
 
         title = book_response_json['title']
         summary = book_response_json['oneLiner']

--- a/pugsebot/commands/book.py
+++ b/pugsebot/commands/book.py
@@ -1,4 +1,4 @@
-"""Define packt command."""
+"""Define book command."""
 
 import datetime
 
@@ -6,13 +6,13 @@ from utils.command_base import CommandBase
 from utils.time import UM_DIA_EM_SEGUNDOS
 from utils.request import get_json
 
-class Packt(CommandBase):
-    """Configure packt command."""
+class Book(CommandBase):
+    """Configure book command."""
 
     def __init__(self):
         """Pass arguments to CommandBase init."""
         super().__init__(
-            name='packt',
+            name='book',
             help_text='Livro gratúito do Packt Learning',
             reply_function_name='reply_text',
             schedule_interval=UM_DIA_EM_SEGUNDOS,
@@ -21,25 +21,25 @@ class Packt(CommandBase):
 
     def function(self, update=None, context=None):
         """Return a free book from Packt Learning."""
-        date1 = datetime.datetime.now()
-        date2 = date1 + datetime.timedelta(days=1)
-        date1 = date1.strftime('%Y-%m-%d')
-        date2 = date2.strftime('%Y-%m-%d')
-        url = (
+        startDate = datetime.datetime.now()
+        endDate = startDate + datetime.timedelta(days=1)
+        startDateFormated = startDate.strftime('%Y-%m-%d')
+        endDateFormated = endDate.strftime('%Y-%m-%d')
+        promotion_url = (
             'https://services.packtpub.com/free-learning-v1/'
-            f'offers?dateFrom={date1}&dateTo={date2}'
+            f'offers?dateFrom={startDateFormated}&dateTo={endDateFormated}'
         )
-        response_json = get_json(url)
-        book_id = response_json['data'][0]['productId']
+        promotion_response_json = get_json(promotion_url)
+        book_id = promotion_response_json['data'][0]['productId']
 
         url = (
             'https://static.packt-cdn.com/products/'
             f'{book_id}/summary'
         )
-        response_json = get_json(url)
+        book_response_json = get_json(url)
 
-        title = response_json['title']
-        summary = response_json['oneLiner']
+        title = book_response_json['title']
+        summary = book_response_json['oneLiner']
 
         return (
             'Livro gratuito da Packt Learning hoje:\n'

--- a/pugsebot/commands/packt.py
+++ b/pugsebot/commands/packt.py
@@ -1,0 +1,47 @@
+"""Define packt command."""
+
+import datetime
+
+from utils.command_base import CommandBase
+from utils.time import UM_DIA_EM_SEGUNDOS
+from utils.request import get_json
+
+class Packt(CommandBase):
+    """Configure packt command."""
+
+    def __init__(self):
+        """Pass arguments to CommandBase init."""
+        super().__init__(
+            name='packt',
+            help_text='Livro gratúito do Packt Learning',
+            reply_function_name='reply_text',
+            schedule_interval=UM_DIA_EM_SEGUNDOS,
+            expire=UM_DIA_EM_SEGUNDOS,
+        )
+
+    def function(self, update=None, context=None):
+        """Return a free book from Packt Learning."""
+        date1 = datetime.datetime.now()
+        date2 = date1 + datetime.timedelta(days=1)
+        date1 = date1.strftime('%Y-%m-%d')
+        date2 = date2.strftime('%Y-%m-%d')
+        url = (
+            'https://services.packtpub.com/free-learning-v1/'
+            f'offers?dateFrom={date1}&dateTo={date2}'
+        )
+        response_json = get_json(url)
+        book_id = response_json['data'][0]['productId']
+
+        url = (
+            'https://static.packt-cdn.com/products/'
+            f'{book_id}/summary'
+        )
+        response_json = get_json(url)
+
+        title = response_json['title']
+        summary = response_json['oneLiner']
+
+        return (
+            'Livro gratuito da Packt Learning hoje:\n'
+            '<a href="https://www.packtpub.com/free-learning">'
+            f'{title}</a>\n{summary}')

--- a/pugsebot/tests.py
+++ b/pugsebot/tests.py
@@ -20,7 +20,7 @@ import commands.projects
 import commands.say
 import commands.udemy
 import commands.help
-import commands.packt
+import commands.book
 
 utils.logging.set_level('ERROR')
 
@@ -610,7 +610,7 @@ class TestPackt(unittest.TestCase):
 
     def test_function(self):
         """Test packt function."""
-        result = commands.packt.Packt().function()
+        result = commands.book.Book().function()
         self.assertIn('Livro', result)
         self.assertIn('gratuito', result)
         self.assertIn(

--- a/pugsebot/tests.py
+++ b/pugsebot/tests.py
@@ -605,11 +605,11 @@ class TestAbout(unittest.TestCase):
         self.assertIn('comunidade', result)
         self.assertIn('contribuir', result)
 
-class TestPackt(unittest.TestCase):
-    """Test packt functionalities."""
+class TestBook(unittest.TestCase):
+    """Test book functionalities."""
 
     def test_function(self):
-        """Test packt function."""
+        """Test book function."""
         result = commands.book.Book().function()
         self.assertIn('Livro', result)
         self.assertIn('gratuito', result)

--- a/pugsebot/tests.py
+++ b/pugsebot/tests.py
@@ -20,6 +20,7 @@ import commands.projects
 import commands.say
 import commands.udemy
 import commands.help
+import commands.packt
 
 utils.logging.set_level('ERROR')
 
@@ -603,6 +604,17 @@ class TestAbout(unittest.TestCase):
         result = commands.about.About().function()
         self.assertIn('comunidade', result)
         self.assertIn('contribuir', result)
+
+class TestPackt(unittest.TestCase):
+    """Test packt functionalities."""
+
+    def test_function(self):
+        """Test packt function."""
+        result = commands.packt.Packt().function()
+        self.assertIn('Livro', result)
+        self.assertIn('gratuito', result)
+        self.assertIn(
+            'https://www.packtpub.com/free-learning', result)
 
 class TestLinks(unittest.TestCase):
     """Test links functionalities."""


### PR DESCRIPTION
- Comando /packt: pega o nome e resumo do livro gratuito do dia do Packt Learning

- Desabilitei o preview de links das mensagens do bot, pois estava atrapalhando a formatação das mensagens dos comandos:

1. que enviam múltiplos links (/udemy  /projects etc), pois apenas o primeiro ficava de preview
2. que enviam um único link, pois havia duplicação de links (/news /packt /about etc)
